### PR TITLE
qubes-gpg-split: fix gpg-server path in qubes.Gpg

### DIFF
--- a/app-emulation/qubes-gpg-split/.qubes-gpg-split.ebuild.0
+++ b/app-emulation/qubes-gpg-split/.qubes-gpg-split.ebuild.0
@@ -43,7 +43,9 @@ src_prepare() {
 src_compile() {
     # Remove related /var/run
     sed -i 's|/etc/tmpfiles\.d/|/usr/lib/tmpfiles.d/|g' Makefile
-	sed -i '/^.*\/var\/run\/.*$/d' Makefile
+    sed -i '/^.*\/var\/run\/.*$/d' Makefile
+    # Ensure qubes.Gpg service script will use the correct path
+    sed -i "s|/usr/lib/qubes-gpg-split|/usr/$(get_libdir)/qubes-gpg-split|" qubes.Gpg.service
 
     myopt="${myopt} DESTDIR=${D} SYSTEMD=1 BACKEND_VMM=xen LIBDIR=/usr/$(get_libdir)"
 	emake ${myopt} build


### PR DESCRIPTION
Hello,

First of all great thanks for your efforts both in creating a Gentoo template and providing these ebuilds (including usage of pandoc-bin), as a fairly long term Gentoo user, it feels great to now be able to combine the powers of Gentoo and Qubes!

About this patch, because of setting the option `LIBDIR=/usr/$(get_libdir)`, the `gpg-server` file gets installed into `/usr/lib64/qubes-gpg-split` on `amd64` architecture, whereas the script hardcodes `/usr/lib/qubes-gpg-split` as its path. I went with the sed approach since that was used to fix the makefiles as well but a patch would also do.