### PR TITLE
qubes-gui-agent: fix pulseaudio 15 module-vchan-sink

### DIFF
--- a/app-emulation/qubes-gui-agent/.qubes-gui-agent.ebuild.0
+++ b/app-emulation/qubes-gui-agent/.qubes-gui-agent.ebuild.0
@@ -77,6 +77,16 @@ src_install() {
 }
 
 pkg_postinst() {
+    # With pulseaudio 15.0, the module directory was changed to
+    # /usr/$(get_libdir)/${PN}/modules
+    pa_ver=$((pkg-config --modversion libpulse 2>/dev/null || echo 0.0) | cut -f 1 -d "-")
+    pa_ver_short=$(echo "${pa_ver}" | cut -f 1 -d".")
+    if [[ "${pa_ver_short}" -ge 15 ]]; then
+        mv /usr/$(get_libdir)/pulse-${pa_ver}/modules/module-vchan-sink.so /usr/$(get_libdir)/pulseaudio/modules
+        rmdir /usr/$(get_libdir)/pulse-${pa_ver}/modules
+        rmdir /usr/$(get_libdir)/pulse-${pa_ver}
+    fi
+
     systemctl enable qubes-gui-agent.service
 
     # Remove useless file from install-rh-agent


### PR DESCRIPTION
After a recent update, PulseAudio was not working anymore.

The root cause seems to be that with PulseAudio 15.0, the installation directory for the module was changed, see:
https://gitweb.gentoo.org/repo/gentoo.git/tree/media-sound/pulseaudio/pulseaudio-15.0-r1.ebuild#n196

I decided to push a fix in this repository since version management needs to be done to make this work, but maybe the `qubes-gui-agent-linux` would be appropriate as well.

Note that `repoman` will need to be called after this commit to update the manifest and also for signing.