### PR TITLE
Fix GPL LICENSE variables

### DIFF
--- a/app-emulation/qubes-core-agent-linux/.qubes-core-agent-linux.ebuild.0
+++ b/app-emulation/qubes-core-agent-linux/.qubes-core-agent-linux.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-core-agent-linux.git"
 KEYWORDS="amd64"
 DESCRIPTION="The Qubes core files for installation inside a Qubes VM"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE="networking network-manager passwordless-root pandoc-bin"

--- a/app-emulation/qubes-core-qrexec/.qubes-core-qrexec.ebuild.0
+++ b/app-emulation/qubes-core-qrexec/.qubes-core-qrexec.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-core-qrexec.git"
 KEYWORDS="amd64"
 DESCRIPTION="The Qubes qrexec files (qube side)"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE="pandoc-bin"

--- a/app-emulation/qubes-db/.qubes-db.ebuild.0
+++ b/app-emulation/qubes-db/.qubes-db.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-core-qubesdb.git"
 KEYWORDS="amd64"
 DESCRIPTION="QubesDB libs and daemon service"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE=""

--- a/app-emulation/qubes-gpg-split/.qubes-gpg-split.ebuild.0
+++ b/app-emulation/qubes-gpg-split/.qubes-gpg-split.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-app-linux-split-gpg.git"
 KEYWORDS="amd64"
 DESCRIPTION="The Qubes service for secure gpg separation"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE="pandoc-bin"

--- a/app-emulation/qubes-gui-agent/.qubes-gui-agent.ebuild.0
+++ b/app-emulation/qubes-gui-agent/.qubes-gui-agent.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-gui-agent-linux.git"
 KEYWORDS="amd64"
 DESCRIPTION="The Qubes GUI Agent for AppVMs"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE="xfce"

--- a/app-emulation/qubes-gui-common/.qubes-gui-common.ebuild.0
+++ b/app-emulation/qubes-gui-common/.qubes-gui-common.ebuild.0
@@ -15,7 +15,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-gui-common.git"
 KEYWORDS="amd64"
 DESCRIPTION="Common files for Qubes GUI - protocol headers"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE=""

--- a/app-emulation/qubes-img-converter/.qubes-img-converter.ebuild.0
+++ b/app-emulation/qubes-img-converter/.qubes-img-converter.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-app-linux-img-converter.git"
 KEYWORDS="amd64"
 DESCRIPTION="The Qubes service for converting untrusted images into trusted ones"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE=""

--- a/app-emulation/qubes-input-proxy/.qubes-input-proxy.ebuild.0
+++ b/app-emulation/qubes-input-proxy/.qubes-input-proxy.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-app-linux-input-proxy.git"
 KEYWORDS="amd64"
 DESCRIPTION="Simple input device proxy"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE=""

--- a/app-emulation/qubes-libvchan-xen/.qubes-libvchan-xen.ebuild.0
+++ b/app-emulation/qubes-libvchan-xen/.qubes-libvchan-xen.ebuild.0
@@ -15,7 +15,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-core-vchan-xen.git"
 KEYWORDS="amd64"
 DESCRIPTION="QubesOS libvchan cross-domain communication library"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE=""

--- a/app-emulation/qubes-pdf-converter/.qubes-pdf-converter.ebuild.0
+++ b/app-emulation/qubes-pdf-converter/.qubes-pdf-converter.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-app-linux-pdf-converter.git"
 KEYWORDS="amd64"
 DESCRIPTION="The Qubes service for converting untrusted PDF files into trusted ones"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE="pandoc-bin"

--- a/app-emulation/qubes-thunderbird/.qubes-thunderbird.ebuild.0
+++ b/app-emulation/qubes-thunderbird/.qubes-thunderbird.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-app-thunderbird.git"
 KEYWORDS="amd64"
 DESCRIPTION="The Qubes extension for Thunderbird"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE=""

--- a/app-emulation/qubes-usb-proxy/.qubes-usb-proxy.ebuild.0
+++ b/app-emulation/qubes-usb-proxy/.qubes-usb-proxy.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-app-linux-usb-proxy.git"
 KEYWORDS="amd64"
 DESCRIPTION="USBIP wrapper to run it over Qubes RPC connection"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE=""

--- a/app-emulation/qubes-utils/.qubes-utils.ebuild.0
+++ b/app-emulation/qubes-utils/.qubes-utils.ebuild.0
@@ -17,7 +17,7 @@ EGIT_REPO_URI="https://github.com/QubesOS/qubes-linux-utils.git"
 KEYWORDS="amd64"
 DESCRIPTION="Common Linux files for Qubes VM"
 HOMEPAGE="http://www.qubes-os.org"
-LICENSE="GPLv2"
+LICENSE="GPL-2"
 
 SLOT="0"
 IUSE=""


### PR DESCRIPTION
License format for GPL in ebuilds is "GPL-#" rather than "GPLv#"
[Documentation here](https://devmanual.gentoo.org/general-concepts/licenses/index.html)