### PR TITLE
app-emulation/qubes-core-agent-linux: Add nautilus integration

### DIFF
--- a/app-emulation/qubes-core-agent-linux/.qubes-core-agent-linux.ebuild.0
+++ b/app-emulation/qubes-core-agent-linux/.qubes-core-agent-linux.ebuild.0
@@ -20,7 +20,7 @@ HOMEPAGE="http://www.qubes-os.org"
 LICENSE="GPL-2"
 
 SLOT="0"
-IUSE="networking network-manager passwordless-root pandoc-bin"
+IUSE="nautilus networking network-manager passwordless-root pandoc-bin"
 
 DEPEND="app-emulation/qubes-libvchan-xen
         app-emulation/qubes-db
@@ -46,6 +46,9 @@ DEPEND="app-emulation/qubes-libvchan-xen
                 net-misc/networkmanager
                 net-firewall/nftables
             )
+        )
+        nautilus? (
+            dev-python/nautilus-python
         )
         ${PYTHON_DEPS}
         "
@@ -86,6 +89,9 @@ src_install() {
     emake ${myopt} -C package-managers install
     if use passwordless-root; then
         emake ${myopt} -C passwordless-root install
+    fi
+    if use nautilus; then
+        emake ${myopt} -C qubes-rpc/nautilus install
     fi
 
     if use networking; then


### PR DESCRIPTION
Add nautilus use flag. If enabled, install files from qubes-rpc/nautilus
folder.

This enables Copy/Move to AppVM in context menu.