### PR TITLE
Rebuild qubes-gui-agent if xorg-server slot changes

### DIFF
--- a/app-emulation/qubes-gui-agent/.qubes-gui-agent.ebuild.0
+++ b/app-emulation/qubes-gui-agent/.qubes-gui-agent.ebuild.0
@@ -26,6 +26,7 @@ DEPEND="app-emulation/qubes-libvchan-xen
         app-emulation/qubes-db
         app-emulation/qubes-gui-common
         x11-base/xorg-x11
+        x11-base/xorg-server:=
         x11-libs/libXdamage
         x11-apps/xinit
         x11-libs/libXcomposite


### PR DESCRIPTION
By declaring a := dependency on xorg-server, we tell portage that qubes-gui-agent needs to be rebuilt if xorg-server is updated. This mirrors the behavior seen by other x11-drivers.

See QubesOS/qubes-issues#7228