### PR TITLE
Fix qubes-input-proxy not prompting on attach

### DIFF
--- a/app-emulation/qubes-input-proxy/.qubes-input-proxy.ebuild.0
+++ b/app-emulation/qubes-input-proxy/.qubes-input-proxy.ebuild.0
@@ -4,7 +4,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..13} )
 
-inherit git-r3 multilib distutils-r1 qubes
+inherit git-r3 distutils-r1 qubes
 
 if [[ ${PV} == *9999 ]]; then
 	EGIT_COMMIT=HEAD
@@ -35,7 +35,7 @@ src_prepare() {
 }
 
 src_compile() {
-    myopt="${myopt} DESTDIR=${D} SYSTEMD=1 BACKEND_VMM=xen LIBDIR=/usr/$(get_libdir)"
+    myopt="${myopt} DESTDIR=${D} SYSTEMD=1 BACKEND_VMM=xen LIBDIR=/usr/lib"
 	emake ${myopt} all
 }
 


### PR DESCRIPTION
Udev rules were placed in /usr/lib64 instead of /usr/lib, but udev only reads from /usr/lib, this meant that they were never seen, causing the qrexec prompt to never appear on device attach.