### PR TITLE
Switch ebuilds to the python-14 version

### DIFF
--- a/app-emulation/qubes-core-agent-linux/.qubes-core-agent-linux.ebuild.0
+++ b/app-emulation/qubes-core-agent-linux/.qubes-core-agent-linux.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib distutils-r1 qubes
 

--- a/app-emulation/qubes-core-qrexec/.qubes-core-qrexec.ebuild.0
+++ b/app-emulation/qubes-core-qrexec/.qubes-core-qrexec.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib distutils-r1 qubes
 

--- a/app-emulation/qubes-db/.qubes-db.ebuild.0
+++ b/app-emulation/qubes-db/.qubes-db.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib distutils-r1 qubes
 

--- a/app-emulation/qubes-gpg-split/.qubes-gpg-split.ebuild.0
+++ b/app-emulation/qubes-gpg-split/.qubes-gpg-split.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib distutils-r1 qubes
 

--- a/app-emulation/qubes-gui-agent/.qubes-gui-agent.ebuild.0
+++ b/app-emulation/qubes-gui-agent/.qubes-gui-agent.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib distutils-r1 qubes
 

--- a/app-emulation/qubes-img-converter/.qubes-img-converter.ebuild.0
+++ b/app-emulation/qubes-img-converter/.qubes-img-converter.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib qubes
 

--- a/app-emulation/qubes-input-proxy/.qubes-input-proxy.ebuild.0
+++ b/app-emulation/qubes-input-proxy/.qubes-input-proxy.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 distutils-r1 qubes
 

--- a/app-emulation/qubes-pdf-converter/.qubes-pdf-converter.ebuild.0
+++ b/app-emulation/qubes-pdf-converter/.qubes-pdf-converter.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib distutils-r1 qubes
 

--- a/app-emulation/qubes-shutdown-idle/.qubes-shutdown-idle.ebuild.0
+++ b/app-emulation/qubes-shutdown-idle/.qubes-shutdown-idle.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib distutils-r1 qubes
 

--- a/app-emulation/qubes-thunderbird/.qubes-thunderbird.ebuild.0
+++ b/app-emulation/qubes-thunderbird/.qubes-thunderbird.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib distutils-r1 qubes
 

--- a/app-emulation/qubes-usb-proxy/.qubes-usb-proxy.ebuild.0
+++ b/app-emulation/qubes-usb-proxy/.qubes-usb-proxy.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib distutils-r1 qubes
 

--- a/app-emulation/qubes-utils/.qubes-utils.ebuild.0
+++ b/app-emulation/qubes-utils/.qubes-utils.ebuild.0
@@ -2,7 +2,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{10..13} )
+PYTHON_COMPAT=( python3_{11..14} )
 
 inherit git-r3 multilib distutils-r1 qubes
 


### PR DESCRIPTION
Switch ebuilds to the 11..14 python range with the soon default python-14.
source:  [Python 3.14 to become the default on 2026-06-01](https://www.gentoo.org/support/news-items/2026-04-16-python3-14.html)